### PR TITLE
feat: support for Decimal128 by using float8

### DIFF
--- a/server/src/pgwire_duck/table.rs
+++ b/server/src/pgwire_duck/table.rs
@@ -5,7 +5,7 @@ use pg_wire::protocol_ext::DataWriter;
 use duckdb::arrow::array::{
 	BooleanArray, Date32Array, Date64Array, Float16Array, Float32Array, Float64Array, Int16Array, Int32Array,
 	Int64Array, Int8Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-	TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+	TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array, Decimal128Array,
 };
 use duckdb::arrow::datatypes::{DataType, Schema, TimeUnit};
 use duckdb::arrow::record_batch::RecordBatch;
@@ -47,6 +47,7 @@ pub fn record_batch_to_rows(arrow_batch: &RecordBatch, pg_batch: &mut DataWriter
 					DataType::Float16 => row.write_float4(array_val!(Float16Array, col, row_idx).to_f32()),
 					DataType::Float32 => row.write_float4(array_val!(Float32Array, col, row_idx)),
 					DataType::Float64 => row.write_float8(array_val!(Float64Array, col, row_idx)),
+					DataType::Decimal128(p, s) => row.write_float8(decimal128_into_f64(array_val!(Decimal128Array, col, row_idx), p.clone(), s.clone())),
 					DataType::Utf8 => row.write_string(array_val!(StringArray, col, row_idx)),
 					DataType::Date32 => {
 						row.write_date(array_val!(Date32Array, col, row_idx, value_as_date).ok_or_else(|| {
@@ -102,6 +103,7 @@ pub fn data_type_to_oid(ty: &DataType) -> Result<DataTypeOid, ErrorResponse> {
 		DataType::UInt64 => DataTypeOid::Int8,
 		DataType::Float16 | DataType::Float32 => DataTypeOid::Float4,
 		DataType::Float64 => DataTypeOid::Float8,
+		DataType::Decimal128(_,_) => DataTypeOid::Float8,
 		DataType::Utf8 => DataTypeOid::Text,
 		DataType::Date32 | DataType::Date64 => DataTypeOid::Date,
 		DataType::Timestamp(_, None) => DataTypeOid::Timestamp,
@@ -127,3 +129,13 @@ pub fn schema_to_field_desc(schema: &Schema) -> Result<Vec<FieldDescription>, Er
 		})
 		.collect()
 }
+
+pub fn decimal128_into_f64(val: i128, _precision: u8, scale: u8) -> f64 {
+	let mul = (10 as i64).pow(scale as u32) as i128;
+	let num = val / mul;
+	let rounded  = num * mul;
+	let left_over = (val - rounded) as f64;
+	let fraction = left_over/mul as f64;
+	let result = (num as f64) + fraction;
+	result
+} 


### PR DESCRIPTION
## Description
Add support for Decimal128 which is used for the `Numeric` Postgres type by using `float8` as the underlying type.

## Known Limitation
A numeric type is a complex number that can be also used to represent a decimal with exact precision. 
However, with the current approach, that same precision is lost due to the use of float8.

## Alternative
- Use PostgreSQL protocol to directly write a numeric value
- Use `String` representation instead of `float8`, so we don't loss information about exact precision, etc.

