### PR TITLE
feat: load default extension support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target
 *.wal
-*.db
+
+# ignore tests database
+test.db
+test.csv
+test.parquet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "duckdb",
+ "futures",
  "pg-wire",
  "r2d2",
  "tokio",

--- a/pg-wire/src/connection.rs
+++ b/pg-wire/src/connection.rs
@@ -120,7 +120,11 @@ impl<E: Engine> Connection<E> {
 					framed.send(ParameterStatus::new(param, status)).await?;
 				}
 
+				// startup the engine before ready to be queried
+				self.engine.startup().await?;
+
 				framed.send(ReadyForQuery).await?;
+
 				Ok(Some(ConnectionState::Idle))
 			}
 			ConnectionState::Idle => {

--- a/pg-wire/src/engine.rs
+++ b/pg-wire/src/engine.rs
@@ -1,6 +1,6 @@
 //! Contains core interface definitions for custom SQL engines.
 
-use crate::protocol::{ErrorResponse, FieldDescription};
+use crate::protocol::{ErrorResponse, FieldDescription, Startup};
 use crate::protocol_ext::DataWriter;
 use async_trait::async_trait;
 
@@ -22,9 +22,12 @@ pub trait Engine: Send + Sync + 'static {
 	/// The [Portal] implementation used by [Engine::create_portal].
 	type PortalType: Portal;
 
+	/// Prepare the engine during Startup state of the postgresql conenection
+	async fn startup(&mut self) -> Result<(), ErrorResponse>;
+
 	/// Prepares a statement, returning a vector of field descriptions for the final statement result.
-	async fn prepare(&mut self, stmt: &String) -> Result<Vec<FieldDescription>, ErrorResponse>;
+	async fn prepare(&mut self, query: &String) -> Result<Vec<FieldDescription>, ErrorResponse>;
 
 	/// Creates a new portal for the given String.
-	async fn create_portal(&mut self, stmt: &String) -> Result<Self::PortalType, ErrorResponse>;
+	async fn create_portal(&mut self, query: &String) -> Result<Self::PortalType, ErrorResponse>;
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,3 +15,4 @@ duckdb = { git="https://github.com/euiko/duckdb-rs", branch="add-get-arrow-schem
 pg-wire = { path = "../pg-wire", version = "0.1.0" }
 async-trait = "0.1"
 r2d2 = "0.8.10"
+futures = "0.3"

--- a/server/src/pgwire_duck/duckdb.rs
+++ b/server/src/pgwire_duck/duckdb.rs
@@ -1,107 +1,139 @@
-use std::path::Path;
-use duckdb::{DuckdbConnectionManager};
-use duckdb::arrow::record_batch::RecordBatch;
-use pg_wire::protocol::{ErrorResponse, FieldDescription, SqlState};
-use pg_wire::engine::{Portal, Engine};
-use pg_wire::protocol_ext::DataWriter;
-use r2d2::Pool;
 use super::table::{record_batch_to_rows, schema_to_field_desc};
 use async_trait::async_trait;
+use duckdb::arrow::record_batch::RecordBatch;
+use duckdb::DuckdbConnectionManager;
+use futures::executor;
+use pg_wire::engine::{Engine, Portal};
+use pg_wire::protocol::{ErrorResponse, FieldDescription, SqlState};
+use pg_wire::protocol_ext::DataWriter;
+use r2d2::Pool;
+use std::path::Path;
+use std::vec;
 
 #[derive(Debug)]
 pub enum EngineError {
-	PoolError(r2d2::Error),
-	DuckdbError(duckdb::Error),
+    PoolError(r2d2::Error),
+    DuckdbError(duckdb::Error),
 }
 
-
 pub struct DuckDBPortal {
-	fields: Vec<FieldDescription>,
+    fields: Vec<FieldDescription>,
     records: Vec<RecordBatch>,
 }
 
 #[async_trait]
 impl Portal for DuckDBPortal {
-	async fn fetch(&mut self, w: &mut DataWriter) -> Result<(), ErrorResponse> {
-		w.set_fields(self.fields.to_owned());
-		for arrow_batch in &self.records {
-			record_batch_to_rows(&arrow_batch, w)?;
-		}
-		Ok(())
-	}
+    async fn fetch(&mut self, w: &mut DataWriter) -> Result<(), ErrorResponse> {
+        w.set_fields(self.fields.to_owned());
+        for arrow_batch in &self.records {
+            record_batch_to_rows(&arrow_batch, w)?;
+        }
+        Ok(())
+    }
 }
 
 pub struct DuckDBEngine {
-    pool: Pool<DuckdbConnectionManager>
+    pool: Pool<DuckdbConnectionManager>,
 }
 
 impl DuckDBEngine {
-	pub fn new(manager: DuckdbConnectionManager) -> Result<Self, EngineError> {
-		let pool = Pool::builder()
-			.min_idle(Some(4))
-			.max_size(16)
-			.build(manager)
-			.map_err(EngineError::PoolError)?;
-		Ok(Self{ pool })
-	}
-	
+    pub fn new(manager: DuckdbConnectionManager) -> Result<Self, EngineError> {
+        let pool = Pool::builder()
+            .min_idle(Some(4))
+            .max_size(16)
+            .build(manager)
+            .map_err(EngineError::PoolError)?;
+        Ok(Self { pool })
+    }
+
     pub fn file<P: AsRef<Path>>(path: P) -> Result<Self, EngineError> {
-		let manager = DuckdbConnectionManager::file(path).map_err(EngineError::DuckdbError)?;
-		Self::new(manager)
+        let manager = DuckdbConnectionManager::file(path).map_err(EngineError::DuckdbError)?;
+        Self::new(manager)
+    }
+}
+
+impl DuckDBEngine {
+    async fn load_extension(&mut self, extension: &str) -> Result<(), ErrorResponse> {
+		println!("loading extension {}", extension);
+
+        // load the extension first
+        let query = format!("LOAD {}", extension);
+        self.create_portal(&query).await?;
+
+        // then install it
+        let query = format!("INSTALL {}", extension);
+        self.create_portal(&query).await?;
+
+        Ok(())
     }
 }
 
 #[async_trait]
 impl Engine for DuckDBEngine {
-	type PortalType = DuckDBPortal;
+    type PortalType = DuckDBPortal;
 
-	async fn prepare(&mut self, _: &String) -> Result<Vec<FieldDescription>, ErrorResponse> {
+    async fn startup(&mut self) -> Result<(), ErrorResponse> {
+        // default extension to load during connection
+        let extensions = vec!["parquet", "json", "excel"];
+
+        let success = extensions
+            .iter()
+            .map(|e| executor::block_on(async { self.load_extension(e).await }))
+            .all(|i| match i {
+                Ok(_) => true,
+                _ => false,
+            });
+
+		if !success {
+			return Err(ErrorResponse::error(SqlState::CONNECTION_EXCEPTION, "cannot initialize default plugin"));
+		}
+
+        Ok(())
+    }
+
+    async fn prepare(&mut self, _: &String) -> Result<Vec<FieldDescription>, ErrorResponse> {
         // DuckDB doesn't support multi-stage query execution
-		// the field description will be set during Portal's fetch
-		Ok(vec![])
-	}
+        // the field description will be set during Portal's fetch
+        Ok(vec![])
+    }
 
-	async fn create_portal(&mut self, query: &String) -> Result<Self::PortalType, ErrorResponse> {
-		let conn = self.pool.get()
-			.map_err(|e| ErrorResponse::error(
-				SqlState::CONNECTION_EXCEPTION, 
-				format!("cannot retrieve lock to connection : {}", e.to_string()), 
-			))?;
+    async fn create_portal(&mut self, query: &String) -> Result<Self::PortalType, ErrorResponse> {
+        let conn = self.pool.get().map_err(|e| {
+            ErrorResponse::error(
+                SqlState::CONNECTION_EXCEPTION,
+                format!("cannot retrieve lock to connection : {}", e.to_string()),
+            )
+        })?;
 
-		let mut stmt = conn.prepare(&query).map_err(to_wire_error)?;
-		let records: Vec<RecordBatch> = stmt.query_arrow([])
-			.map_err(to_wire_error)?
-			.collect();
-		let schema = stmt.schema();
-		let fields = schema_to_field_desc(&schema)?;
-		Ok(DuckDBPortal { fields, records })
-	}
+        let mut stmt = conn.prepare(&query).map_err(to_wire_error)?;
+        let records: Vec<RecordBatch> = stmt.query_arrow([]).map_err(to_wire_error)?.collect();
+        let schema = stmt.schema();
+        let fields = schema_to_field_desc(&schema)?;
+        Ok(DuckDBPortal { fields, records })
+    }
 }
 
 fn to_wire_error(e: duckdb::Error) -> ErrorResponse {
-	let state = match e {
-				duckdb::Error::DuckDBFailure(_, _) => SqlState::CONNECTION_EXCEPTION, 
-				duckdb::Error::FromSqlConversionFailure(_, _, _) => SqlState::SYNTAX_ERROR,
-				duckdb::Error::IntegralValueOutOfRange(_, _) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::Utf8Error(_) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::NulError(_) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::InvalidParameterName(_) => SqlState::SYNTAX_ERROR,
-				duckdb::Error::InvalidPath(_) => SqlState::SYNTAX_ERROR,
-				duckdb::Error::ExecuteReturnedResults => SqlState::DATA_EXCEPTION,
-				duckdb::Error::QueryReturnedNoRows => SqlState::DATA_EXCEPTION,
-				duckdb::Error::InvalidColumnIndex(_) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::InvalidColumnName(_) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::InvalidColumnType(_, _, _) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::StatementChangedRows(_) => SqlState::DATA_EXCEPTION,
-				duckdb::Error::ToSqlConversionFailure(_) => SqlState::SYNTAX_ERROR,
-				duckdb::Error::InvalidQuery => SqlState::SYNTAX_ERROR,
-				duckdb::Error::MultipleStatement => SqlState::SYNTAX_ERROR,
-				duckdb::Error::InvalidParameterCount(_, _) => SqlState::SYNTAX_ERROR,
-				duckdb::Error::AppendError => SqlState::DATA_EXCEPTION,
-				_ => todo!()
-	};
-	ErrorResponse::error(
-		state,
-		e.to_string(),
-	)
+    let state = match e {
+        duckdb::Error::DuckDBFailure(_, _) => SqlState::CONNECTION_EXCEPTION,
+        duckdb::Error::FromSqlConversionFailure(_, _, _) => SqlState::SYNTAX_ERROR,
+        duckdb::Error::IntegralValueOutOfRange(_, _) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::Utf8Error(_) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::NulError(_) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::InvalidParameterName(_) => SqlState::SYNTAX_ERROR,
+        duckdb::Error::InvalidPath(_) => SqlState::SYNTAX_ERROR,
+        duckdb::Error::ExecuteReturnedResults => SqlState::DATA_EXCEPTION,
+        duckdb::Error::QueryReturnedNoRows => SqlState::DATA_EXCEPTION,
+        duckdb::Error::InvalidColumnIndex(_) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::InvalidColumnName(_) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::InvalidColumnType(_, _, _) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::StatementChangedRows(_) => SqlState::DATA_EXCEPTION,
+        duckdb::Error::ToSqlConversionFailure(_) => SqlState::SYNTAX_ERROR,
+        duckdb::Error::InvalidQuery => SqlState::SYNTAX_ERROR,
+        duckdb::Error::MultipleStatement => SqlState::SYNTAX_ERROR,
+        duckdb::Error::InvalidParameterCount(_, _) => SqlState::SYNTAX_ERROR,
+        duckdb::Error::AppendError => SqlState::DATA_EXCEPTION,
+        _ => todo!(),
+    };
+    ErrorResponse::error(state, e.to_string())
 }


### PR DESCRIPTION
## Description
Add default extension support to be loaded during PostgreSQL connection startup.
It allows developers to use a certain extension to be available without the need to load them manually.

The support has been added by adding a new `startup()` method to the `Engine` interface that will be called during the connection's startup state.
Then the `DuckDBEngine` implementation will do the loading of the default extensions that have been defined.

## Known Limitation
The current approach is by using a naive query to install and load those default extensions.
However, there is still a case during load extension that the installation is failed, because the DuckDB internally is trying to load the extension from a remote repository when there is no one found in the local filesystem.
And this process can be failed due to various reasons, one of the failures is that may hang the server entirely when the loading extension from the remote is take indefinitely a long time.